### PR TITLE
fix for my starwars boost hub

### DIFF
--- a/src/BoostHub.h
+++ b/src/BoostHub.h
@@ -1,9 +1,9 @@
 /*
  * BoostHub.h - Arduino Library for controlling Boost hubs
- * 
+ *
  * (c) Copyright 2019 - Cornelius Munz
  * Released under MIT License
- * 
+ *
 */
 
 #ifndef BoostHub_h
@@ -19,12 +19,14 @@ public:
     //Port definitions specific to Boost Hubs
   enum Port
   {
-    A = 0x37,
-    B = 0x38,
-    AB = 0x39,
-    C = 0x01,
-    D = 0x02,
-    TILT = 0x3A
+    A = 0x00,
+    B = 0x01,
+    AB = 0x10,
+    C = 0x02,
+    D = 0x03,
+    TILT = 0x3A,
+    CURRENT = 0x3B,
+    VOLTAGE = 0x3C
   };
 
   //Constructor


### PR DESCRIPTION
This seems to work with the boost hub i got from the star wars set, But I don't know if it's specific to this one.