### PR TITLE
Deducing Hub type automatically using advertising

### DIFF
--- a/examples/PoweredUpRemoteAutoDetection/PoweredUpRemoteAutoDetection.ino
+++ b/examples/PoweredUpRemoteAutoDetection/PoweredUpRemoteAutoDetection.ino
@@ -1,0 +1,119 @@
+/**
+ * A Legoino example to connect to a Powered Up remote and a train hub. 
+ * 
+ * 1) Power up the ESP32
+ * 2) Power up the Remote and the Train Hub in any order
+ * 
+ * You can change the motor speed with the left (A) remote buttons
+ * 
+ * (c) Copyright 2019 - Nicolas HILAIRE
+ * Released under MIT License
+ * 
+ */
+
+#include "PoweredUpRemote.h"
+#include "PoweredUpHub.h"
+
+// create a hub instance
+PoweredUpRemote myRemote;
+PoweredUpHub myHub;
+
+PoweredUpRemote::Port _portLeft = PoweredUpRemote::Port::LEFT;
+PoweredUpRemote::Port _portRight = PoweredUpRemote::Port::RIGHT;
+PoweredUpHub::Port _portA = PoweredUpHub::Port::A;
+
+int currentSpeed = 0;
+int updatedSpeed = 0;
+bool isInitialized = false;
+
+void setup() {
+    Serial.begin(115200);
+    myRemote.init(); // initalize the listening hub
+    myHub.init(); // initalize the listening hub
+} 
+
+
+// main loop
+void loop() {
+
+  //wait for two elements
+
+  if (myRemote.isConnecting())
+  {
+    if (myRemote.getHubType() == POWERED_UP_REMOTE)
+    {
+      //This is the right device 
+      if (!myRemote.connectHub())
+      {
+        Serial.println("Unable to connect to hub");
+      }
+      else
+      {
+        myRemote.setLedColor(GREEN);
+        Serial.println("Remote connected.");
+      }
+      
+    }
+  }
+
+  if (myHub.isConnecting())
+  {
+    if (myHub.getHubType() == POWERED_UP_HUB)
+    {
+     // myHub._isConnecting = true;
+      //myHub._pServerAddress = new BLEAddress(myListeningHub._pServerAddress->toString()); 
+      myHub.connectHub();
+      myHub.setLedColor(GREEN);
+      Serial.println("powered up hub connected.");
+    }
+  }
+
+  if (!myRemote.isConnected())
+  {
+    myRemote.init();
+  }
+
+  if (! myHub.isConnected())
+  {
+    myHub.init();
+  }
+  
+  if (myRemote.isConnected() && myHub.isConnected() && !isInitialized) {
+     Serial.println("System is initialized");
+      isInitialized = true;
+      // both activations are needed to get status updates
+      myRemote.activateButtonReports(); 
+      myRemote.activatePortDevice(_portLeft, 55);
+      myRemote.activatePortDevice(_portRight, 55);
+      myRemote.setLedColor(WHITE);
+      myHub.setLedColor(WHITE);
+  }
+
+  // if connected we can control the train motor on Port A with the remote
+  if (isInitialized) {
+
+    if (myRemote.isLeftRemoteUpButtonPressed() || myRemote.isRightRemoteUpButtonPressed()) {
+      myRemote.setLedColor(GREEN);
+      updatedSpeed = min(100, currentSpeed+10);
+    } else if (myRemote.isLeftRemoteDownButtonPressed() || myRemote.isRightRemoteDownButtonPressed()) {
+      myRemote.setLedColor(BLUE);
+      updatedSpeed = min(100, currentSpeed-10);
+    } else if (myRemote.isLeftRemoteStopButtonPressed() || myRemote.isRightRemoteStopButtonPressed()) {
+      myRemote.setLedColor(RED);
+      updatedSpeed = 0;
+    } else if (myRemote.isLeftRemoteButtonReleased() || myRemote.isRightRemoteButtonReleased()) {
+      myRemote.setLedColor(WHITE);      
+    }
+
+    if (currentSpeed != updatedSpeed) {
+      myHub.setMotorSpeed(_portA, updatedSpeed);
+      currentSpeed = updatedSpeed;
+    }
+
+    Serial.print("Current speed:");
+    Serial.println(currentSpeed, DEC);
+    delay(100);
+
+  }
+  
+} // End of loop

--- a/src/Lpf2Hub.cpp
+++ b/src/Lpf2Hub.cpp
@@ -25,6 +25,7 @@ int Lpf2HubColor;
 // Hub information values
 int Lpf2HubRssi;
 uint8_t Lpf2HubBatteryLevel;
+HubType Lpf2HubType;
 int Lpf2HubHubMotorRotation;
 bool Lpf2HubHubButtonPressed;
 
@@ -80,6 +81,21 @@ public:
         {
             advertisedDevice.getScan()->stop();
             _lpf2Hub->_pServerAddress = new BLEAddress(advertisedDevice.getAddress());
+            LOG("Advertising : ");
+            uint8_t * payload = advertisedDevice.getPayload();
+            for(int i=0; i<advertisedDevice.getPayloadLength(); i++) {
+                LOG(payload[i], HEX); 
+            }
+            LOGLINE();
+
+            //check for device capabilities and device type ID
+            if (payload[26] == 0x42 && payload[27] == 0x0A)
+                _lpf2Hub->_hubType = POWERED_UP_REMOTE;
+            else if (payload[26] == 0x41 && payload[27] == 0x07)
+                _lpf2Hub->_hubType = POWERED_UP_HUB;
+            //TODO : add else if on BOOST_MOVE_HUB for those which have it to test !!!
+            else 
+                _lpf2Hub->_hubType = UNKNOWN;
             _lpf2Hub->_isConnecting = true;
         }
     }
@@ -334,6 +350,13 @@ void Lpf2Hub::parseDeviceInfo(uint8_t *pData)
             LOG("Recharchable");
         }
         LOGLINE();
+    }
+    else if (pData[3] == 0x0B) // System type ID
+    {
+        LOG("System type ID: ");
+        uint8_t typeId = ReadUInt8(pData, 5);
+        LOG(typeId);
+        //Lpf2HubType
     }
 }
 
@@ -592,6 +615,7 @@ void Lpf2Hub::init()
     _isConnecting = false;
     _bleUuid = BLEUUID(LPF2_UUID);
     _charachteristicUuid = BLEUUID(LPF2_CHARACHTERISTIC);
+    _hubType = UNKNOWN;
 
     BLEDevice::init("");
     BLEScan *pBLEScan = BLEDevice::getScan();
@@ -934,6 +958,11 @@ int Lpf2Hub::getHardwareVersionMajor()
 int Lpf2Hub::getHardwareVersionMinor()
 {
     return Lpf2HubHardwareVersionMinor;
+}
+
+HubType Lpf2Hub::getHubType()
+{
+    return _hubType;
 }
 
 bool Lpf2Hub::isButtonPressed()

--- a/src/Lpf2Hub.h
+++ b/src/Lpf2Hub.h
@@ -32,6 +32,7 @@ typedef enum HubType
   BOOST_MOVE_HUB = 2,
   POWERED_UP_HUB = 3,
   POWERED_UP_REMOTE = 4,
+  UNKNOWN = 255,
 };
 
 typedef enum DeviceType
@@ -78,8 +79,6 @@ typedef enum Color
 class Lpf2Hub
 {
 private:
-  // BLE properties
-  HubType _hubType;
   // device properties
   int _rssi = -100;
   int _batteryLevel = 100; //%
@@ -160,6 +159,7 @@ int getHardwareVersionBuild();
 int getHardwareVersionBugfix();
 int getHardwareVersionMajor();
 int getHardwareVersionMinor();
+HubType getHubType();
 bool isButtonPressed();
 bool isLeftRemoteUpButtonPressed();
 bool isLeftRemoteDownButtonPressed();
@@ -177,6 +177,7 @@ bool isRightRemoteButtonReleased();
 
   boolean _isConnecting;
   boolean _isConnected;
+  HubType _hubType;
 };
 
 #endif


### PR DESCRIPTION
I'm using your library connecting a train to its remote with more functionnalities than the original command allows.
I'm using your sample PoweredUpRemote and the order of the connection (Firstly the remote and after the train) was a little annoying, So I used the advertising to know which hub just arrive to ask to the right object to connect.
Modifications are very small. I added an new example file inspired from PoweredUpRemote sample.