### PR TITLE
A minimal change to make working emulated Hub with PoweredUp on Android

### DIFF
--- a/src/Lpf2HubEmulation.cpp
+++ b/src/Lpf2HubEmulation.cpp
@@ -37,6 +37,13 @@ public:
     _lpf2HubEmulation->isConnected = false;
     _lpf2HubEmulation->isPortInitialized = false;
   }
+
+  // This is required to make it working with BLE Scanner and PoweredUp on devices with Android <6.
+  // TODO: find out why this method helps. Maybe it goes about timeout?
+  void onConnect(NimBLEServer* pServer, ble_gap_conn_desc* desc)
+  {
+    pServer->updateConnParams(desc->conn_handle, 24, 48, 0, 60);
+  };
 };
 
 class Lpf2HubCharacteristicCallbacks : public NimBLECharacteristicCallbacks
@@ -413,7 +420,10 @@ void Lpf2HubEmulation::start()
   if (_hubType == HubType::POWERED_UP_HUB)
   {
     log_d("PoweredUp Hub");
-    const char poweredUpHub[8] = {0x97, 0x03, 0x00, 0x41, 0x07, 0x1D, 0x63, 0x00};
+    // this is the minimal change that makes PoweredUp working on devices with Android <6
+    // https://lego.github.io/lego-ble-wireless-protocol-docs/index.html#last-network-id
+    // set Last Network ID to UNKNOWN (0x00)
+    const char poweredUpHub[8] = {0x97, 0x03, 0x00, 0x41, 0x07, 0x00, 0x63, 0x00};
     manufacturerData = std::string(poweredUpHub, sizeof(poweredUpHub));
   }
   else if (_hubType == HubType::CONTROL_PLUS_HUB)

--- a/src/Lpf2HubEmulation.cpp
+++ b/src/Lpf2HubEmulation.cpp
@@ -39,6 +39,7 @@ public:
   }
 
   // This is required to make it working with BLE Scanner and PoweredUp on devices with Android <6.
+  // This seems to be not needed for Android >=6
   // TODO: find out why this method helps. Maybe it goes about timeout?
   void onConnect(NimBLEServer* pServer, ble_gap_conn_desc* desc)
   {
@@ -433,6 +434,9 @@ void Lpf2HubEmulation::start()
     manufacturerData = std::string(controlPlusHub, sizeof(controlPlusHub));
   }
   NimBLEAdvertisementData advertisementData = NimBLEAdvertisementData();
+  // flags must be present to make PoweredUp working on devices with Android >=6
+  // (however it seems to be not needed for devices with Android <6)
+  advertisementData.setFlags(BLE_HS_ADV_F_DISC_GEN);
   advertisementData.setManufacturerData(manufacturerData);
   advertisementData.setCompleteServices(NimBLEUUID(LPF2_UUID));
   // scan response data is needed because the uuid128 and manufacturer data takes almost all space in the advertisement data


### PR DESCRIPTION
This is a proposed fix for issue #27.

PoweredUp should work without restartin (or clearing its cache), so there is some improvement here. I have noticed that sometimes I need to restart bluetooth to make it working (especially when I flashed a new and modified software to ESP32).

My test devices:
 * Samsung Galaxy J3 (2016) with Android 5.1.1 and PoweredUp 3.5.0
 * Huawei SNE-LX1 with Android 10 and PoweredUp 3.5.0

Please retest.