### PR TITLE
Add include for std::string

### DIFF
--- a/src/LegoinoCommon.h
+++ b/src/LegoinoCommon.h
@@ -13,6 +13,7 @@
 
 #include "Arduino.h"
 #include "Lpf2HubConst.h"
+#include <string>
 
 class LegoinoCommon
 {


### PR DESCRIPTION
Add missing include for std::string.

Although this library complies on Arduino ESP32 v1.0.6 board it does not compile on the latest (v2.0.2) Arduino ESP32 board.
Arduino IDE: 1.8.15