### PR TITLE
Prevent Lpf2Hub from multiple initializing

### DIFF
--- a/src/Lpf2Hub.cpp
+++ b/src/Lpf2Hub.cpp
@@ -10,12 +10,16 @@
 
 #include "Lpf2Hub.h"
 
+boolean Lpf2Hub::_isInitializing = false;
+
+
 /** 
  * Callback if a scan has ended with the results of found devices 
  * only needed to enforce the non blocking scan start
  */
-void scanEndedCallback(NimBLEScanResults results)
+void Lpf2Hub::scanEndedCallback(NimBLEScanResults results)
 {
+    _isInitializing = false;
     log_d("Number of devices: %d", results.getCount());
     for (int i = 0; i < results.getCount(); i++)
     {
@@ -799,13 +803,22 @@ void Lpf2Hub::notifyCallback(
 /**
  * @brief Constructor
  */
-Lpf2Hub::Lpf2Hub(){};
+Lpf2Hub::Lpf2Hub() {};
 
 /**
  * @brief Init function set the UUIDs and scan for the Hub
  */
 void Lpf2Hub::init()
 {
+    if (_isInitializing)
+    {
+        return;
+    }
+    else
+    {
+        _isInitializing = true;
+    }
+
     _isConnected = false;
     _isConnecting = false;
     _bleUuid = BLEUUID(LPF2_UUID);

--- a/src/Lpf2Hub.h
+++ b/src/Lpf2Hub.h
@@ -123,6 +123,7 @@ public:
   std::string parseHubAdvertisingName(uint8_t *pData);
 
   // BLE specific stuff
+  static void scanEndedCallback(NimBLEScanResults results);
   void notifyCallback(NimBLERemoteCharacteristic *pBLERemoteCharacteristic, uint8_t *pData, size_t length, bool isNotify);
   BLEUUID _bleUuid;
   BLEUUID _charachteristicUuid;
@@ -134,6 +135,7 @@ public:
   std::string _hubName;
   boolean _isConnecting;
   boolean _isConnected;
+  static boolean _isInitializing;
 
 private:
   // Notification callbacks


### PR DESCRIPTION
Calling `Lpf2Hub::init()` repeatedly from the loop function causes the ESP32 to crash and reboot, see issue #56.

I believe the origin of this problem is that `init()` does not check if a BLE scan is currently ongoing before creating another, noting that the function returns before the scan is complete.

My solution is to create a static variable in the `Lpf2Hub` class, which is set by the `init()` method, and cleared by the scan end callback function.

Resolves #56 