### PR TITLE
init() returns immediately if already scanning

### DIFF
--- a/src/Lpf2Hub.cpp
+++ b/src/Lpf2Hub.cpp
@@ -806,6 +806,11 @@ Lpf2Hub::Lpf2Hub(){};
  */
 void Lpf2Hub::init()
 {
+    if (isScanning())
+    {
+        return;
+    }
+
     _isConnected = false;
     _isConnecting = false;
     _bleUuid = BLEUUID(LPF2_UUID);


### PR DESCRIPTION
Replaces PR #72 with a simpler solution.

Within the `init()` function, check whether a scan is already ongoing. If so, return immediately. This prevents resets from repeated initalisation within a loop.

Closes #60.